### PR TITLE
remove_indexes_h5.py fix: move break logic to start of loop.

### DIFF
--- a/utilities/tile_cleaning/remove_indexes_h5.py
+++ b/utilities/tile_cleaning/remove_indexes_h5.py
@@ -60,17 +60,17 @@ def create_complete_h5(data_path, num_tiles, key_dict, indexes_to_remove, overri
             set_dict[key] = content[key]
 
         for i in range(set_dict[key].shape[0]):
+            if num_tiles == index:
+                break
+            
             # Original data.
             for key in storage_dict:
                 storage_dict[key][index] = set_dict[key][i]
             
             # Check if this is a tile to remove
             if i in indexes_to_remove:
-            	indexes_to_remove.remove(i)
-            	continue
-
-            if num_tiles == index:
-                break
+                indexes_to_remove.remove(i)
+                continue
 
             # Verbose.
             if i%1e+5==0:   


### PR DESCRIPTION
Before fix, since `index` is updated at the end of the loop after checking the stop condition, `index` is incremented past `num_tiles` and gives an IndexError in next iteration.

Since the error happens after all retained items are copied over, it seems it doesn't cause issues, but the error message can still be misleading or lead to issues in the future if subsequent logic is added.